### PR TITLE
Add note about GetWriteToken() for automated builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ For detailed documentation, see the [GoDocs](http://godoc.org/github.com/Century
 
       fmt.Printf("%#v", tags)
     }
+
+## Write token caveat
+
+Please note that the `GetWriteToken()` only works on **non automated build**s.


### PR DESCRIPTION
It wasn't trivial the reason for 403 error, might save others the headache ...
