### PR TITLE
Sets request body properly for requests other than GET

### DIFF
--- a/registry/hub.go
+++ b/registry/hub.go
@@ -58,7 +58,13 @@ func (h *HubService) GetDeleteToken(repo string, auth Authenticator) (*TokenAuth
 }
 
 func (h *HubService) newRequest(method, urlStr string, auth Authenticator) (*http.Request, error) {
-	req, err := h.client.newRequest(method, urlStr, auth, nil)
+	var req *http.Request
+	var err error
+	if method == "GET" {
+		req, err = h.client.newRequest(method, urlStr, auth, nil)
+	} else {
+		req, err = h.client.newRequest(method, urlStr, auth, []string{})
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
sets a request body when the method type isn't GET. This fixes any errors recieved from doing PUTs with no request body as most registries would expect
